### PR TITLE
[Fix] double+ nested case

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const ampRegExp = /&/g
 const classRegExp = /\.(\w+)/g
+const extraPointsRegExp = /^\.+(.*?)$/
 
 // The RegExp to process local class selectors is slightly more complex.
 // To make it easier to read we build it incrementally:
@@ -58,7 +59,7 @@ export default function jssRefs() {
     // Look for ampersands in property names which indicates a nested rule:
     Object.keys(rule.style).forEach(prop => {
       const parentSelector = rule.name ? `.${rule.name}` : rule.selector
-      const selector = prop.replace(ampRegExp, parentSelector)
+      const selector = prop.replace(ampRegExp, parentSelector).replace(extraPointsRegExp, `.$1`)
       if (selector !== prop) {
         // If the strings differ there was a match.
         // Remove the style declaration and create a new rule:

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 const ampRegExp = /&/g
 const classRegExp = /\.(\w+)/g
-const extraPointsRegExp = /^\.+(.*?)$/
+const extraPointsRegExp = /\.+(\w+)/g
 
 // The RegExp to process local class selectors is slightly more complex.
 // To make it easier to read we build it incrementally:

--- a/test/index.js
+++ b/test/index.js
@@ -216,8 +216,16 @@ test('double nested rule resolved correctly', function () {
           color: 'green'
         }
       }
+    },
+    b: {
+      '& > li': {
+        '& > div, & > span,&>div,    &> span': {
+          color: 'red'
+        }
+      }
     }
   })
   ok(sheet.rules['.a--jss-0-0'])
-  equal(sheet.toString(), '.a--jss-0-0 > li.active {\n  color: green;\n}')
+  ok(sheet.rules['.b--jss-0-3'])
+  equal(sheet.toString(), '.a--jss-0-0 > li.active {\n  color: green;\n}\n.b--jss-0-3 > li > div, .b--jss-0-3 > li > span,.b--jss-0-3 > li>div,    .b--jss-0-3 > li> span {\n  color: red;\n}')
 })

--- a/test/index.js
+++ b/test/index.js
@@ -207,3 +207,17 @@ test('nesting in a conditional namespaced rule', function () {
   ok(sheet.rules['@media'])
   equal(sheet.toString(), '.a--jss-0-0 {\n  color: green;\n}\n@media {\n  .a--jss-0-0:hover {\n    color: red;\n  }\n}')
 })
+test('double nested rule resolved correctly', function () {
+  jss.uid.reset()
+  var sheet = jss.createStyleSheet({
+    a: {
+      '& > li': {
+        '&global(.active)': {
+          color: 'green'
+        }
+      }
+    }
+  })
+  ok(sheet.rules['.a--jss-0-0'])
+  equal(sheet.toString(), '.a--jss-0-0 > li.active {\n  color: green;\n}')
+})


### PR DESCRIPTION
rule:
```
{
    a: {
      '& > li': {
        '&global(.active)': {
          color: 'green'
        }
      }
    }
  }
```

expectation:
```
.a--jss-0-0 > li.active {
  color: green;
}
```

outcome:
```
..a--jss-0-0 > li.active {
  color: green;
}
```

PR has tests and fix for case mentioned above